### PR TITLE
Add caching for gitignore templates and implement clear cache command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the "yagi" extension will be documented in this file.
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## [0.0.1] - 2025-04-19
-### Added
+
 - Initial release of YAGI extension
 - Generate .gitignore files using the Toptal gitignore API
 - Select multiple templates for .gitignore generation
@@ -13,10 +13,13 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Command palette integration
 
 ## [0.0.2] - 2025-04-20
-### Added
-- Update README with usage instructions
--
 
+- Update README with usage instructions
+
+## [0.0.3] - 2025-04-21
+
+- Implement caching for gitignore templates and add clear cache command
 
 ## [Unreleased]
+
 - Upcoming features and improvements


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced caching for gitignore template lists and generated content to improve performance and reduce network usage.
  - Added a command to clear all cached data directly from the extension.

- **Documentation**
  - Updated the changelog to reflect new features and made minor formatting improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->